### PR TITLE
Abstracted logger

### DIFF
--- a/PokemonGo.RocketAPI.Console/Program.cs
+++ b/PokemonGo.RocketAPI.Console/Program.cs
@@ -1,25 +1,15 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
-using System.Linq;
-using System.Net.Http;
-using System.Text;
 using System.Threading.Tasks;
-using AllEnum;
-using Google.Protobuf;
-using PokemonGo.RocketAPI.Enums;
 using PokemonGo.RocketAPI.Exceptions;
-using PokemonGo.RocketAPI.Extensions;
-using PokemonGo.RocketAPI.GeneratedCode;
-using PokemonGo.RocketAPI.Helpers;
 
 namespace PokemonGo.RocketAPI.Console
 {
     class Program
     {
-        
         static void Main(string[] args)
         {
+            Logger.SetLogger(new Logging.ConsoleLogger(LogLevel.Info));
+
             Task.Run(() =>
             {
                 try
@@ -28,16 +18,14 @@ namespace PokemonGo.RocketAPI.Console
                 }
                 catch (PtcOfflineException)
                 {
-                    System.Console.WriteLine("PTC Servers are probably down OR your credentials are wrong. Try google");
+                    Logger.Write("PTC Servers are probably down OR your credentials are wrong. Try google", LogLevel.Error);
                 }
                 catch (Exception ex)
                 {
-                    System.Console.WriteLine($"Unhandled exception: {ex}");
+                    Logger.Write($"Unhandled exception: {ex}", LogLevel.Error);
                 }
             });
              System.Console.ReadLine();
         }
-
-        
     }
 }

--- a/PokemonGo.RocketAPI.Logic/Logic.cs
+++ b/PokemonGo.RocketAPI.Logic/Logic.cs
@@ -26,7 +26,7 @@ namespace PokemonGo.RocketAPI.Logic
 
         public async void Execute()
         {
-            Console.WriteLine($"Starting Execute on login server: {_clientSettings.AuthType}");
+            Logger.Write($"Starting Execute on login server: {_clientSettings.AuthType}", LogLevel.Info);
             
             if (_clientSettings.AuthType == AuthType.Ptc)
                 await _client.DoPtcLogin(_clientSettings.PtcUsername, _clientSettings.PtcPassword);
@@ -53,7 +53,7 @@ namespace PokemonGo.RocketAPI.Logic
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"Exception: {ex}");
+                    Logger.Write($"Exception: {ex}", LogLevel.Error);
                 }
 
                 await Task.Delay(10000);
@@ -78,7 +78,7 @@ namespace PokemonGo.RocketAPI.Logic
                 var fortInfo = await client.GetFort(pokeStop.Id, pokeStop.Latitude, pokeStop.Longitude);
                 var fortSearch = await client.SearchFort(pokeStop.Id, pokeStop.Latitude, pokeStop.Longitude);
 
-                System.Console.WriteLine($"[{DateTime.Now.ToString("HH:mm:ss")}] Farmed XP: {fortSearch.ExperienceAwarded}, Gems: { fortSearch.GemsAwarded}, Eggs: {fortSearch.PokemonDataEgg} Items: {StringUtils.GetSummedFriendlyNameOfItemAwardList(fortSearch.ItemsAwarded)}");
+                Logger.Write($"Farmed XP: {fortSearch.ExperienceAwarded}, Gems: { fortSearch.GemsAwarded}, Eggs: {fortSearch.PokemonDataEgg} Items: {StringUtils.GetSummedFriendlyNameOfItemAwardList(fortSearch.ItemsAwarded)}", LogLevel.Info);
 
                 await Task.Delay(15000);
                 await ExecuteCatchAllNearbyPokemons(client);
@@ -103,7 +103,7 @@ namespace PokemonGo.RocketAPI.Logic
                 }
                 while (caughtPokemonResponse.Status == CatchPokemonResponse.Types.CatchStatus.CatchMissed);
 
-                System.Console.WriteLine(caughtPokemonResponse.Status == CatchPokemonResponse.Types.CatchStatus.CatchSuccess ? $"[{DateTime.Now.ToString("HH:mm:ss")}] We caught a {pokemon.PokemonId} with CP {encounterPokemonResponse?.WildPokemon?.PokemonData?.Cp}" : $"[{DateTime.Now.ToString("HH:mm:ss")}] {pokemon.PokemonId} with CP {encounterPokemonResponse?.WildPokemon?.PokemonData?.Cp} got away..");
+                Logger.Write(caughtPokemonResponse.Status == CatchPokemonResponse.Types.CatchStatus.CatchSuccess ? $"We caught a {pokemon.PokemonId} with CP {encounterPokemonResponse?.WildPokemon?.PokemonData?.Cp}" : $"{pokemon.PokemonId} with CP {encounterPokemonResponse?.WildPokemon?.PokemonData?.Cp} got away..", LogLevel.Info);
                 await Task.Delay(5000);
             }
         }
@@ -118,9 +118,9 @@ namespace PokemonGo.RocketAPI.Logic
                     evolvePokemonOutProto = await _client.EvolvePokemon((ulong)pokemon.Id); 
 
                     if (evolvePokemonOutProto.Result == EvolvePokemonOut.Types.EvolvePokemonStatus.PokemonEvolvedSuccess)
-                        System.Console.WriteLine($"Evolved {pokemon.PokemonType} successfully for {evolvePokemonOutProto.ExpAwarded}xp");
+                        Logger.Write($"Evolved {pokemon.PokemonType} successfully for {evolvePokemonOutProto.ExpAwarded}xp", LogLevel.Info);
                     else
-                        System.Console.WriteLine($"Failed to evolve {pokemon.PokemonType}. EvolvePokemonOutProto.Result was {evolvePokemonOutProto.Result}, stopping evolving {pokemon.PokemonType}");
+                        Logger.Write($"Failed to evolve {pokemon.PokemonType}. EvolvePokemonOutProto.Result was {evolvePokemonOutProto.Result}, stopping evolving {pokemon.PokemonType}", LogLevel.Info);
 
                     await Task.Delay(3000);
                 }
@@ -132,13 +132,13 @@ namespace PokemonGo.RocketAPI.Logic
 
         private async Task TransferDuplicatePokemon()
         {
-            System.Console.WriteLine($"Transfering duplicate Pokemon");
+            Logger.Write($"Transfering duplicate Pokemon", LogLevel.Info);
 
             var duplicatePokemons = await _inventory.GetDuplicatePokemonToTransfer();
             foreach (var duplicatePokemon in duplicatePokemons)
             {
                 var transfer = await _client.TransferPokemon(duplicatePokemon.Id);
-                System.Console.WriteLine($"Transfer {duplicatePokemon.PokemonId} with {duplicatePokemon.Cp})");
+                Logger.Write($"Transfer {duplicatePokemon.PokemonId} with {duplicatePokemon.Cp})", LogLevel.Info);
                 await Task.Delay(500);
             }
         }

--- a/PokemonGo.RocketAPI/Extensions/HttpClientExtensions.cs
+++ b/PokemonGo.RocketAPI/Extensions/HttpClientExtensions.cs
@@ -14,7 +14,7 @@ namespace PokemonGo.RocketAPI.Extensions
     {
         public static async Task<TResponsePayload> PostProtoPayload<TRequest, TResponsePayload>(this HttpClient client, string url, TRequest request) where TRequest : IMessage<TRequest> where TResponsePayload : IMessage<TResponsePayload>, new()
         {
-            Console.WriteLine($"{DateTime.Now.ToString("HH:mm:ss")} requesting {typeof(TResponsePayload).Name}");
+            Logger.Write($"Requesting {typeof(TResponsePayload).Name}", LogLevel.Debug);
             var response = await PostProto<TRequest>(client, url, request);
 
             //Decode payload

--- a/PokemonGo.RocketAPI/Helpers/RetryHandler.cs
+++ b/PokemonGo.RocketAPI/Helpers/RetryHandler.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using PokemonGo.RocketAPI.Logging;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
@@ -33,7 +34,7 @@ namespace PokemonGo.RocketAPI.Helpers
                 }
                 catch (Exception ex)
                 {
-                    System.Console.WriteLine($"retry request {request.RequestUri}");
+                    Logger.Write($"retry request {request.RequestUri}", LogLevel.Warning);
                     if (i < MaxRetries)
                     {
                         await Task.Delay(1000);

--- a/PokemonGo.RocketAPI/Logger.cs
+++ b/PokemonGo.RocketAPI/Logger.cs
@@ -1,0 +1,43 @@
+﻿using PokemonGo.RocketAPI.Logging;
+
+namespace PokemonGo.RocketAPI
+{
+	/// <summary>
+	/// Generic logger which can be used across the projects.
+	/// Logger should be set to properly log.
+	/// </summary>
+	public static class Logger
+	{
+		private static ILogger logger;
+
+		/// <summary>
+		/// Set the logger. All future requests to <see cref="Write(string, LogLevel)"/> will use that logger, any old will be unset.
+		/// </summary>
+		/// <param name="logger"></param>
+		public static void SetLogger(ILogger logger)
+		{
+			Logger.logger = logger;
+		}
+
+		/// <summary>
+		/// Log a specific message to the logger setup by <see cref="SetLogger(ILogger)"/> .
+		/// </summary>
+		/// <param name="message">The message to log.</param>
+		/// <param name="level">Optional level to log. Default <see cref="LogLevel.Info"/>.</param>
+		public static void Write(string message, LogLevel level = LogLevel.Info)
+		{
+			if (logger == null)
+				return;
+			logger.Write(message, level);
+		}
+	}
+
+	public enum LogLevel
+	{
+		None = 0,
+		Error = 1,
+		Warning = 2,
+		Info = 3,
+		Debug = 4
+	}
+}

--- a/PokemonGo.RocketAPI/Logging/ConsoleLogger.cs
+++ b/PokemonGo.RocketAPI/Logging/ConsoleLogger.cs
@@ -1,0 +1,35 @@
+﻿using System;
+
+namespace PokemonGo.RocketAPI.Logging
+{
+	/// <summary>
+	/// The ConsoleLogger is a simple logger which writes all logs to the Console.
+	/// </summary>
+	public class ConsoleLogger : ILogger
+	{
+		private LogLevel maxLogLevel;
+
+		/// <summary>
+		/// To create a ConsoleLogger, we must define a maximum log level.
+		/// All levels above won't be logged.
+		/// </summary>
+		/// <param name="maxLogLevel"></param>
+		public ConsoleLogger(LogLevel maxLogLevel)
+		{
+			this.maxLogLevel = maxLogLevel;
+		}
+
+		/// <summary>
+		/// Log a specific message by LogLevel. Won't log if the LogLevel is greater than the maxLogLevel set.
+		/// </summary>
+		/// <param name="message">The message to log. The current time will be prepended.</param>
+		/// <param name="level">Optional. Default <see cref="LogLevel.Info"/>.</param>
+		public void Write(string message, LogLevel level = LogLevel.Info)
+		{
+			if (level > maxLogLevel)
+				return;
+
+			Console.WriteLine($"[{ DateTime.Now.ToString("HH:mm:ss")}] { message}");
+		}
+	}
+}

--- a/PokemonGo.RocketAPI/Logging/ILogger.cs
+++ b/PokemonGo.RocketAPI/Logging/ILogger.cs
@@ -1,0 +1,15 @@
+﻿namespace PokemonGo.RocketAPI.Logging
+{
+	/// <summary>
+	/// All loggers must implement this interface.
+	/// </summary>
+	public interface ILogger
+	{
+		/// <summary>
+		/// Log a specific message by LogLevel.
+		/// </summary>
+		/// <param name="message">The message to log.</param>
+		/// <param name="level">Optional. Default <see cref="LogLevel.Info"/>.</param>
+		void Write(string message, LogLevel level = LogLevel.Info);
+	}
+}

--- a/PokemonGo.RocketAPI/Login/GoogleLogin.cs
+++ b/PokemonGo.RocketAPI/Login/GoogleLogin.cs
@@ -22,7 +22,7 @@ namespace PokemonGo.RocketAPI.Login
         internal static async Task<TokenResponseModel> GetAccessToken()
         {
             var deviceCodeResponse = await GetDeviceCode();
-            Console.WriteLine("Please visit " + deviceCodeResponse.verification_url + " and enter " + deviceCodeResponse.user_code);
+            Logger.Write("Please visit " + deviceCodeResponse.verification_url + " and enter " + deviceCodeResponse.user_code, LogLevel.None);
 
             //Poll until user submitted code..
             TokenResponseModel tokenResponse;

--- a/PokemonGo.RocketAPI/PokemonGo.RocketAPI.csproj
+++ b/PokemonGo.RocketAPI/PokemonGo.RocketAPI.csproj
@@ -91,6 +91,9 @@
     <Compile Include="Helpers\S2Helper.cs" />
     <Compile Include="Helpers\Utils.cs" />
     <Compile Include="ISettings.cs" />
+    <Compile Include="Logging\ConsoleLogger.cs" />
+    <Compile Include="Logging\ILogger.cs" />
+    <Compile Include="Logger.cs" />
     <Compile Include="Login\GoogleLogin.cs" />
     <Compile Include="Login\PtcLogin.cs" />
     <None Include="app.config" />


### PR DESCRIPTION
I've abstracted the logger. Each message can have a 'Level', which can be logged or ignored depending on the settings.

The default 'ConsoleLogger' replicates the behavior currently used. It is no longer necessary to add the timestamp to every Console.WriteLine line, this is also handled by the ConsoleLogger.

Furthermore, the abstraction allows for different implementation of the logger. Using this, you can use the logs in any client built upon this API.