### PR TITLE
Move user config to json & add itemRecycleFilter preset

### DIFF
--- a/PokemonGo.RocketAPI.Console/App.config
+++ b/PokemonGo.RocketAPI.Console/App.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <configSections>
-        <sectionGroup name="userSettings" type="System.Configuration.UserSettingsGroup, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" >
+        <sectionGroup name="userSettings" type="System.Configuration.UserSettingsGroup, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
             <section name="PokemonGo.RocketAPI.Console.UserSettings" type="System.Configuration.ClientSettingsSection, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" allowExeDefinition="MachineToLocalUser" requirePermission="false" />
             <section name="PokemonGo.RocketAPI.Console.Settings" type="System.Configuration.ClientSettingsSection, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" allowExeDefinition="MachineToLocalUser" requirePermission="false" />
         </sectionGroup>

--- a/PokemonGo.RocketAPI.Console/App.config
+++ b/PokemonGo.RocketAPI.Console/App.config
@@ -19,23 +19,11 @@
   </runtime>
   <userSettings>
     <PokemonGo.RocketAPI.Console.UserSettings>
-      <setting name="AuthType" serializeAs="String">
-        <value>Google</value>
-      </setting>
-      <setting name="PtcUsername" serializeAs="String">
-        <value>username</value>
-      </setting>
-      <setting name="PtcPassword" serializeAs="String">
-        <value>pw</value>
-      </setting>
       <setting name="GoogleRefreshToken" serializeAs="String">
         <value />
       </setting>
-      <setting name="DefaultLatitude" serializeAs="String">
-        <value>52.379189</value>
-      </setting>
-      <setting name="DefaultLongitude" serializeAs="String">
-        <value>4.899431</value>
+      <setting name="ConfigFile" serializeAs="String">
+        <value>config.json</value>
       </setting>
     </PokemonGo.RocketAPI.Console.UserSettings>
   </userSettings>

--- a/PokemonGo.RocketAPI.Console/PokemonGo.RocketAPI.Console.csproj
+++ b/PokemonGo.RocketAPI.Console/PokemonGo.RocketAPI.Console.csproj
@@ -64,7 +64,9 @@
     <None Include="App.config">
       <SubType>Designer</SubType>
     </None>
-    <None Include="config.json" />
+    <None Include="config.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Include="packages.config" />
     <None Include="UserSettings.settings">
       <Generator>SettingsSingleFileGenerator</Generator>

--- a/PokemonGo.RocketAPI.Console/PokemonGo.RocketAPI.Console.csproj
+++ b/PokemonGo.RocketAPI.Console/PokemonGo.RocketAPI.Console.csproj
@@ -36,6 +36,10 @@
       <HintPath>..\packages\Google.Protobuf.3.0.0-beta3\lib\dotnet\Google.Protobuf.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />

--- a/PokemonGo.RocketAPI.Console/PokemonGo.RocketAPI.Console.csproj
+++ b/PokemonGo.RocketAPI.Console/PokemonGo.RocketAPI.Console.csproj
@@ -64,6 +64,7 @@
     <None Include="App.config">
       <SubType>Designer</SubType>
     </None>
+    <None Include="config.json" />
     <None Include="packages.config" />
     <None Include="UserSettings.settings">
       <Generator>SettingsSingleFileGenerator</Generator>

--- a/PokemonGo.RocketAPI.Console/Program.cs
+++ b/PokemonGo.RocketAPI.Console/Program.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Threading.Tasks;
 using PokemonGo.RocketAPI.Exceptions;
-
+using System.IO;
 namespace PokemonGo.RocketAPI.Console
 {
     class Program

--- a/PokemonGo.RocketAPI.Console/Settings.cs
+++ b/PokemonGo.RocketAPI.Console/Settings.cs
@@ -25,6 +25,9 @@ namespace PokemonGo.RocketAPI.Console
             PtcPassword = _jsonConfig.ptcPassword;
             DefaultLatitude = _jsonConfig.defaultLatitude;
             DefaultLongitude = _jsonConfig.defaultLongitude;
+            AutoTranferDuplicatePokemon = (bool)_jsonConfig.autoTranferDuplicatePokemon;
+            AutoEvolvePokemon = (bool)_jsonConfig.autoEvolvePokemon;
+            RecycleItem = (bool)_jsonConfig.recycleItem;
             itemRecycleFilter = ((IList<dynamic>)_jsonConfig.itemRecycleFilter).Select(item => new KeyValuePair<ItemId, int>((ItemId)Enum.Parse(typeof(ItemId), string.Format("Item{0}", item.name)), (int)item.amount)).ToArray();
         }
         public AuthType AuthType { get; }
@@ -32,6 +35,10 @@ namespace PokemonGo.RocketAPI.Console
         public string PtcPassword { get; set; }
         public double DefaultLatitude { get; }
         public double DefaultLongitude { get; }
+
+        public bool AutoTranferDuplicatePokemon { get; }
+        public bool AutoEvolvePokemon { get; }
+        public bool RecycleItem { get; }
 
         ICollection<KeyValuePair<ItemId, int>> ISettings.itemRecycleFilter
         {

--- a/PokemonGo.RocketAPI.Console/Settings.cs
+++ b/PokemonGo.RocketAPI.Console/Settings.cs
@@ -24,8 +24,12 @@ namespace PokemonGo.RocketAPI.Console
                 //Type and amount to keep
                 return new[]
                 {
-                    new KeyValuePair<ItemId, int>(ItemId.ItemPokeBall, 50),
-                    new KeyValuePair<ItemId, int>(ItemId.ItemGreatBall, 50)
+                    new KeyValuePair<ItemId, int>(ItemId.ItemPokeBall, 70),
+                    new KeyValuePair<ItemId, int>(ItemId.ItemGreatBall, 100),
+                    new KeyValuePair<ItemId, int>(ItemId.ItemPotion, 10),
+                    new KeyValuePair<ItemId, int>(ItemId.ItemRevive, 30),
+                    new KeyValuePair<ItemId, int>(ItemId.ItemSuperPotion, 20),
+                    new KeyValuePair<ItemId, int>(ItemId.ItemRazzBerry, 80)
                 };
             }
 

--- a/PokemonGo.RocketAPI.Console/UserSettings.Designer.cs
+++ b/PokemonGo.RocketAPI.Console/UserSettings.Designer.cs
@@ -25,42 +25,6 @@ namespace PokemonGo.RocketAPI.Console {
         
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("Google")]
-        public string AuthType {
-            get {
-                return ((string)(this["AuthType"]));
-            }
-            set {
-                this["AuthType"] = value;
-            }
-        }
-        
-        [global::System.Configuration.UserScopedSettingAttribute()]
-        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("username")]
-        public string PtcUsername {
-            get {
-                return ((string)(this["PtcUsername"]));
-            }
-            set {
-                this["PtcUsername"] = value;
-            }
-        }
-        
-        [global::System.Configuration.UserScopedSettingAttribute()]
-        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("pw")]
-        public string PtcPassword {
-            get {
-                return ((string)(this["PtcPassword"]));
-            }
-            set {
-                this["PtcPassword"] = value;
-            }
-        }
-        
-        [global::System.Configuration.UserScopedSettingAttribute()]
-        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("")]
         public string GoogleRefreshToken {
             get {
@@ -73,25 +37,13 @@ namespace PokemonGo.RocketAPI.Console {
         
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("52.379189")]
-        public double DefaultLatitude {
+        [global::System.Configuration.DefaultSettingValueAttribute("config.json")]
+        public string ConfigFile {
             get {
-                return ((double)(this["DefaultLatitude"]));
+                return ((string)(this["ConfigFile"]));
             }
             set {
-                this["DefaultLatitude"] = value;
-            }
-        }
-        
-        [global::System.Configuration.UserScopedSettingAttribute()]
-        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("4.899431")]
-        public double DefaultLongitude {
-            get {
-                return ((double)(this["DefaultLongitude"]));
-            }
-            set {
-                this["DefaultLongitude"] = value;
+                this["ConfigFile"] = value;
             }
         }
     }

--- a/PokemonGo.RocketAPI.Console/UserSettings.settings
+++ b/PokemonGo.RocketAPI.Console/UserSettings.settings
@@ -2,23 +2,11 @@
 <SettingsFile xmlns="http://schemas.microsoft.com/VisualStudio/2004/01/settings" CurrentProfile="(Default)" GeneratedClassNamespace="PokemonGo.RocketAPI.Console" GeneratedClassName="UserSettings">
   <Profiles />
   <Settings>
-    <Setting Name="AuthType" Type="System.String" Scope="User">
-      <Value Profile="(Default)">Google</Value>
-    </Setting>
-    <Setting Name="PtcUsername" Type="System.String" Scope="User">
-      <Value Profile="(Default)">username</Value>
-    </Setting>
-    <Setting Name="PtcPassword" Type="System.String" Scope="User">
-      <Value Profile="(Default)">pw</Value>
-    </Setting>
     <Setting Name="GoogleRefreshToken" Type="System.String" Scope="User">
       <Value Profile="(Default)" />
     </Setting>
-    <Setting Name="DefaultLatitude" Type="System.Double" Scope="User">
-      <Value Profile="(Default)">52.379189</Value>
-    </Setting>
-    <Setting Name="DefaultLongitude" Type="System.Double" Scope="User">
-      <Value Profile="(Default)">4.899431</Value>
+    <Setting Name="ConfigFile" Type="System.String" Scope="User">
+      <Value Profile="(Default)">config.json</Value>
     </Setting>
   </Settings>
 </SettingsFile>

--- a/PokemonGo.RocketAPI.Console/config.json
+++ b/PokemonGo.RocketAPI.Console/config.json
@@ -1,33 +1,36 @@
-{  
-   "authType":"Google",
-   "ptcUsername":"username",
-   "ptcPassword":"pw",
-   "defaultLatitude":52.379189,
-   "defaultLongitude":4.899431,
-   "itemRecycleFilter":[  
-      {  
-         "name":"PokeBall",
-         "amount":70
-      },
-      {  
-         "name":"GreatBall",
-         "amount":100
-      },
-      {  
-         "name":"Potion",
-         "amount":10
-      },
-      {  
-         "name":"Revive",
-         "amount":30
-      },
-      {  
-         "name":"SuperPotion",
-         "amount":20
-      },
-      {  
-         "name":"RazzBerry",
-         "amount":80
-      }
-   ]
+{
+  "authType": "Google",
+  "ptcUsername": "username",
+  "ptcPassword": "pw",
+  "defaultLatitude": 52.379189,
+  "defaultLongitude": 4.899431,
+  "autoTranferDuplicatePokemon": true,
+  "autoEvolvePokemon": false,
+  "recycleItem": true,
+  "itemRecycleFilter": [
+    {
+      "name": "PokeBall",
+      "amount": 70
+    },
+    {
+      "name": "GreatBall",
+      "amount": 100
+    },
+    {
+      "name": "Potion",
+      "amount": 10
+    },
+    {
+      "name": "Revive",
+      "amount": 30
+    },
+    {
+      "name": "SuperPotion",
+      "amount": 20
+    },
+    {
+      "name": "RazzBerry",
+      "amount": 80
+    }
+  ]
 }

--- a/PokemonGo.RocketAPI.Console/config.json
+++ b/PokemonGo.RocketAPI.Console/config.json
@@ -1,0 +1,33 @@
+{  
+   "authType":"Google",
+   "ptcUsername":"username",
+   "ptcPassword":"pw",
+   "defaultLatitude":52.379189,
+   "defaultLongitude":4.899431,
+   "itemRecycleFilter":[  
+      {  
+         "name":"PokeBall",
+         "amount":70
+      },
+      {  
+         "name":"GreatBall",
+         "amount":100
+      },
+      {  
+         "name":"Potion",
+         "amount":10
+      },
+      {  
+         "name":"Revive",
+         "amount":30
+      },
+      {  
+         "name":"SuperPotion",
+         "amount":20
+      },
+      {  
+         "name":"RazzBerry",
+         "amount":80
+      }
+   ]
+}

--- a/PokemonGo.RocketAPI.Console/packages.config
+++ b/PokemonGo.RocketAPI.Console/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Google.Protobuf" version="3.0.0-beta3" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
 </packages>

--- a/PokemonGo.RocketAPI.Logic/Inventory.cs
+++ b/PokemonGo.RocketAPI.Logic/Inventory.cs
@@ -63,9 +63,8 @@ namespace PokemonGo.RocketAPI.Logic
                     var familyCandy = pokemonFamilies.Single(x => settings.FamilyId == x.FamilyId);
                     var amountToSkip = (familyCandy.Candy + settings.CandyToEvolve - 1)/settings.CandyToEvolve;
 
-                    results.AddRange(pokemonList.Where(x => x.PokemonId == pokemon.Key)
+                    results.AddRange(pokemonList.Where(x => x.PokemonId == pokemon.Key && x.Favorite == 0)
                         .OrderByDescending(x => x.Cp)
-                        .Where(x => x.Favorite == 0)
                         .ThenBy(n => n.StaminaMax)
                         .Skip(amountToSkip)
                         .ToList());

--- a/PokemonGo.RocketAPI.Logic/Logic.cs
+++ b/PokemonGo.RocketAPI.Logic/Logic.cs
@@ -38,9 +38,9 @@ namespace PokemonGo.RocketAPI.Logic
                 try
                 {
                     await _client.SetServer();
-                    //await EvolveAllPokemonWithEnoughCandy();
-                    await TransferDuplicatePokemon(true);
-                    await RecycleItems();
+                    if(_clientSettings.AutoEvolvePokemon) await EvolveAllPokemonWithEnoughCandy();
+                    if(_clientSettings.AutoTranferDuplicatePokemon) await TransferDuplicatePokemon(true);
+                    if(_clientSettings.RecycleItem) await RecycleItems();
                     await RepeatAction(5, async () => await ExecuteFarmingPokestopsAndPokemons(_client));
 
                     /*

--- a/PokemonGo.RocketAPI.Logic/Logic.cs
+++ b/PokemonGo.RocketAPI.Logic/Logic.cs
@@ -38,10 +38,10 @@ namespace PokemonGo.RocketAPI.Logic
                 try
                 {
                     await _client.SetServer();
-                    await EvolveAllPokemonWithEnoughCandy();
+                    //await EvolveAllPokemonWithEnoughCandy();
                     await TransferDuplicatePokemon(true);
                     await RecycleItems();
-                    await RepeatAction(10, async () => await ExecuteFarmingPokestopsAndPokemons(_client));
+                    await RepeatAction(5, async () => await ExecuteFarmingPokestopsAndPokemons(_client));
 
                     /*
                 * Example calls below
@@ -108,7 +108,7 @@ namespace PokemonGo.RocketAPI.Logic
                 while (caughtPokemonResponse.Status == CatchPokemonResponse.Types.CatchStatus.CatchMissed);
 
                 Logger.Write(caughtPokemonResponse.Status == CatchPokemonResponse.Types.CatchStatus.CatchSuccess ? $"We caught a {pokemon.PokemonId} with CP {encounterPokemonResponse?.WildPokemon?.PokemonData?.Cp} using a {pokeball}" : $"{pokemon.PokemonId} with CP {encounterPokemonResponse?.WildPokemon?.PokemonData?.Cp} got away while using a {pokeball}..", LogLevel.Info);
-                await Task.Delay(15000);
+                await Task.Delay(5000);
             }
         }
         

--- a/PokemonGo.RocketAPI/ISettings.cs
+++ b/PokemonGo.RocketAPI/ISettings.cs
@@ -12,6 +12,9 @@ namespace PokemonGo.RocketAPI
         string GoogleRefreshToken { get; set; }
         string PtcPassword { get; }
         string PtcUsername { get; }
+        bool AutoTranferDuplicatePokemon { get; }
+        bool AutoEvolvePokemon { get; }
+        bool RecycleItem { get; }
 
         ICollection<KeyValuePair<AllEnum.ItemId, int>> itemRecycleFilter { get; set; }
     }


### PR DESCRIPTION
- Easier to read 
- Update item to recycle without compile
- Control Tranfer,Evolve,Recycle by setting

and able to change config file at UserSetting.ConfigFile

example of json config

```json
{
  "authType": "Google",
  "ptcUsername": "username",
  "ptcPassword": "pw",
  "defaultLatitude": 52.379189,
  "defaultLongitude": 4.899431,
  "autoTranferDuplicatePokemon": true,
  "autoEvolvePokemon": false,
  "recycleItem": true,
  "itemRecycleFilter": [
    {
      "name": "PokeBall",
      "amount": 70
    },
    {
      "name": "GreatBall",
      "amount": 100
    },
    {
      "name": "Potion",
      "amount": 10
    },
    {
      "name": "Revive",
      "amount": 30
    },
    {
      "name": "SuperPotion",
      "amount": 20
    },
    {
      "name": "RazzBerry",
      "amount": 80
    }
  ]
}
```