### PR TITLE
Nuget packaging

### DIFF
--- a/PokemonGo.RocketAPI/PokemonGo.RocketAPI.nuspec
+++ b/PokemonGo.RocketAPI/PokemonGo.RocketAPI.nuspec
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
+    <metadata>
+        <id>PokemonGo.RocketAPI</id>
+        <version>1.0.0-beta</version>
+        <authors>FeroxRev</authors>
+        <owners>Tapanila</owners>
+        <licenseUrl>https://raw.githubusercontent.com/FeroxRev/Pokemon-Go-Rocket-API/master/LICENSE</licenseUrl>
+        <projectUrl>https://github.com/FeroxRev/Pokemon-Go-Rocket-API</projectUrl>
+        <requireLicenseAcceptance>false</requireLicenseAcceptance>
+        <description>Interface to Pokémon Go Client including pretty much every call</description>
+        <releaseNotes>Initial nuget release</releaseNotes>
+        <copyright>Copyright 2016</copyright>
+		<tags>Pokemon, Pokemon Go, PokemonGo</tags>
+    </metadata>
+</package>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,20 @@
+version: 1.0.{build}
+assembly_info:
+  patch: true
+  file: AssemblyInfo.*
+  assembly_version: "{version}"
+  assembly_file_version: "{version}"
+  assembly_informational_version: "{version}"
+configuration: Release
+before_build:
+- ps: nuget restore -PackagesDirectory ./PokemonGo.RocketAPI/packages PokemonGo.RocketAPI/PokemonGo.RocketAPI.csproj
+build_script:
+- ps: msbuild "PokemonGo.RocketAPI\PokemonGo.RocketAPI.csproj" /p:SolutionDir=. /verbosity:minimal /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
+- ps: nuget pack .\PokemonGo.RocketApi\PokemonGo.RocketApi.csproj
+artifacts:
+- path: '*.nupkg'
+  name: Nuget
+deploy:
+- provider: NuGet
+  api_key:
+      secure: 4YYYawFKzaSc0vT1pVxuzWGaiRUEyPO4JOXeDe5rvr5KvYfVEbWziHQ+SJDdBCZI


### PR DESCRIPTION
Added nuspec file that described the nuget package and then added appveyor.yml to automate the creation of nuget package. Fixed #95 

When you want to create and publish a new version to nuget.org you can just update the version number on nuspec file and it will automatically build and publish it.

Package versions needs to contain -beta because google protobuf library is beta.
